### PR TITLE
fix: data type null handling

### DIFF
--- a/lib/services/asus/model/asus_vivowatch_data.dart
+++ b/lib/services/asus/model/asus_vivowatch_data.dart
@@ -15,11 +15,11 @@ class ASUSVivowatchData {
 
   factory ASUSVivowatchData.fromJson(Map<String, dynamic> json) {
     return ASUSVivowatchData(
-      deviceId: json['deviceId'],
-      latestHb: json['latestHb'],
-      latestBp: json['latestBp'],
-      latestSpO2: json['latestSpO2'],
-      latestStep: json['latestStep'],
+      deviceId: json['deviceId'] ?? '',
+      latestHb: json['latestHb'] ?? {},
+      latestBp: json['latestBp'] ?? {},
+      latestSpO2: json['latestSpO2'] ?? {},
+      latestStep: json['latestStep'] ?? {},
     );
   }
 }


### PR DESCRIPTION
Since the Asus API may return null, we need to implement null handling in the app's UI to prevent crashes.